### PR TITLE
feat: board generation by cellular automata

### DIFF
--- a/src/Core.flix
+++ b/src/Core.flix
@@ -243,28 +243,33 @@ namespace Flixball {
             ///
             /// Creates a pseudo-random board from the seed with an average wall
             /// density of `density` in the range [0.0, 1.0]. The map will have
-            /// an encompasing border.
+            /// an encompasing border.  
             ///
-            pub def randomBoard(seed: Int64, rows: {rows::Int32}, cols: Int32, density: Float32): Board = region r {
-                let noise = Flixball/Noise.noise2d(r, width=rows.rows, height=cols, seed);
-                let correctedDensity = density |> Float32.min(1.0f32) |> Float32.max(0.0f32);
-                let densityBoundf32 = (Int32.toFloat32(Int32.maxValue()) * correctedDensity) |> Float32.floor;
-                let densityBound = match Float32.tryToInt32(densityBoundf32) {
-                    case None => ?unreachable
-                    case Some(v) => v
-                };
+            pub def randomBoard(seed: Int64, rows: {rows::Int32}, cols: Int32, density: Float64): Board = region r {
+                let grid = Flixball/Noise.boolNoise2d(r, {width=rows.rows, height=cols}, seed, density);
+                Board({rows=rows.rows, cols=cols, tiles=gridToMap(grid)}) |> addBorder
+            }
+
+            ///
+            /// Cellular Automata Refinement.
+            /// sensible defaults, prob=0.40, iterations=3
+            ///
+            pub def automataBoard(seed: Int64, rows: {rows::Int32}, cols: Int32, density: Float64, iterations: Int32): Board = region r {
+                let grid = Flixball/Noise.cellularGeneration(r, {width=rows.rows, height=cols}, seed, density, iterations);
+                Board({rows=rows.rows, cols=cols, tiles=gridToMap(grid)}) |> addBorder
+            }
+
+            def gridToMap(g: Array[Array[Bool, r], r]): Map[(Int32, Int32), Tile] \ Read(r) =
+                let r = Scoped.regionOf(g);
                 let mutTiles = new MutMap(r);
                 foreach(
-                    (arr, x) <- (Array.iterator(noise) |> Iterator.enumerator);
-                    (value, y) <- Array.iterator(arr) |> Iterator.enumerator)
+                    (arr, x) <- Array.enumerator(g);
+                    (b, y) <- Array.enumerator(arr))
                 {
-                    if (value < densityBound)
-                        mutTiles |> MutMap.put!((x, y), Wall)
+                    if (b) mutTiles |> MutMap.put!((x, y), Wall)
                     else ()
                 };
-                let tiles = MutMap.toMap(mutTiles);
-                Board({rows=rows.rows, cols=cols, tiles=tiles}) |> addBorder
-            }
+                MutMap.toMap(mutTiles)
 
             pub def players(b: Board): List[Player] =
                 let Board(br) = b;

--- a/src/Noise.flix
+++ b/src/Noise.flix
@@ -1,23 +1,95 @@
 namespace Flixball/Noise {
 
+    pub type alias Grid[t: Type, r: Region] = Array[Array[t, r], r]
+
+    pub type alias Dimensions = {width :: Int32, height :: Int32} 
+
+    def createGrid(r: Region[r], f: (Int32, Int32) -> t \ ef, d: Dimensions): Grid[t, r] \ {Write(r), ef} =
+        use Array.init;
+        init(r, x -> init(r, y -> f(x, y), d.height), d.width)
+
     ///
     /// Returns a two-dimensional array of random values >= 0.
     ///
-    pub def noise2d(r: Region[r], width: {width::Int32}, height: {height::Int32}, seed: Int64): Array[Array[Int32, r], r] \ r = region r1 {
-        let w = width.width; let h = height.height;
+    pub def int32Noise2d(r: Region[r], d: Dimensions, seed: Int64): Grid[Int32, r] \ Write(r) = region r1 {
         // avoid r1 being unused
         let _ = r1;
         // This is a safe cast to r since the call sequence to rand is fixed.
         let rand = Random.newWithSeed(seed) as \ r1;
-        let nextInt = Random.nextInt32 as Random.Random -> Int32 \ r1;
-        let arr = Array.init(r, _ -> Array.repeat(r, h, 0), w);
-        foreach(
-            x <- Iterator.range(r, 0, w);
-            y <- Iterator.range(r, 0, h))
-        {
-            arr[x][y] = nextInt(rand) |> Int32.abs
-        };
-        arr
+        let next = Random.nextInt32 as Random.Random -> Int32 \ r1;
+        createGrid(r, (_, _) -> Int32.abs(next(rand)), d)
     }
+
+    ///
+    /// boolean noise with `prob` probability of `true`.
+    /// prob is between 0 and 1 inclusive.
+    ///
+    pub def boolNoise2d(r: Region[r], d: Dimensions, seed: Int64, prob: Float64): Grid[Bool, r] \ Write(r) = region r1 {
+        // avoid r1 being unused
+        let _ = r1;
+        // This is a safe cast to r since the call sequence to rand is fixed.
+        let rand = Random.newWithSeed(seed) as \ Write(r1);
+        let next = x -> Random.nextFloat64(x) as \ {Read(r1), Write(r1)};
+
+        // sample function
+        let clampedProb = prob |> Float64.min(1.0) |> Float64.max(0.0);
+        def sample() = {
+            let randPosFloat = next(rand) |> Float64.abs;
+            randPosFloat < clampedProb
+        };
+        createGrid(r, (_, _) -> sample(), d)
+    }
+
+    ///
+    /// Cellular Automata Refinement.
+    /// sensible defaults, prob=0.40, iterations=3
+    ///
+    pub def cellularGeneration(r: Region[r], d: Dimensions, seed: Int64, prob: Float64, iterations: Int32): Grid[Bool, r] \ Write(r) = region r1 {
+        let floorToWallReq = 4;
+        let wallToFloorReq = 3;
+
+        let current = ref boolNoise2d(r, d, seed, prob) @ r1;
+        let isWall = p -> (deref current)[p.x][p.y];
+        let swap = ref createGrid(r, (_, _) -> false, d) @ r1;
+        // perform automation step in current, storing the result in swap,
+        // and the swapping them.
+        def simulationStep(iteration) = if (iteration <= 0) () else {
+            foreach(
+                (arr, x) <- Array.enumerator(deref current);
+                (_, y) <- Array.enumerator(arr))
+            {
+                let p = {x = x, y = y};
+                let nbh = mooreNeighborhood(p, d);
+                let oob = 8 - List.length(nbh);
+                let wallCount = nbh |> List.count(isWall);
+                if (isWall(p)) {
+                    // stays true/wall if there is enough nearby walls
+                    // and vice versa
+                    (deref swap)[x][y] = oob+wallCount >= wallToFloorReq
+                } else {
+                    // floor/false swaps to wall if there are enough nearby
+                    // walls and vice versa
+                    (deref swap)[x][y] = oob+wallCount > floorToWallReq
+                }
+            };
+            let tmp = deref current;
+            current := deref swap;
+            swap := tmp;
+            simulationStep(iteration-1)
+        };
+        simulationStep(iterations);
+        deref current
+    }
+
+    def mooreNeighborhood(p: {x::Int32, y::Int32}, d: Dimensions): List[{x::Int32, y::Int32}] =
+        let inbound = px -> px.x >= 0 and px.x < d.width and px.y >= 0 and px.y < d.height;
+        let self = px -> px.x == p.x and px.y == p.y;
+        let offsets = List.range(-1, 2);
+        offsets |> List.flatMap(xset ->
+            offsets |> List.filterMap(yset ->
+                let nb = {x=p.x + xset, y=p.y + yset};
+                if (inbound(nb) and not self(nb)) Some(nb) else None
+            )
+        )
 
 }

--- a/src/Utils.flix
+++ b/src/Utils.flix
@@ -22,4 +22,12 @@ namespace Utils {
             x
         } else x
     }
+
+    @Unsafe
+    pub def dbgAny(msg: String, cond: a -> Bool \ ef1, toStr: a -> String \ ef2, x: a): a \ {ef1, ef2} = {
+        if (cond(x)) {
+            println("${msg}: ${toStr(x)}") as \ ef2;
+            x
+        } else x
+    }
 }

--- a/test/TestDisplay.flix
+++ b/test/TestDisplay.flix
@@ -1,7 +1,7 @@
 namespace TestDisplay {
     use Flixball/Core.Board;
     use Flixball/Core.Board.{Board};
-    use Flixball/Core/Board.randomBoard;
+    use Flixball/Core/Board.{randomBoard, automataBoard};
     use Flixball/Core.Direction;
     use Flixball/Core.Direction.{North, West, South, East};
     use Flixball/Core.GameState;
@@ -63,7 +63,10 @@ namespace TestDisplay {
         }}) |> Flixball/Core/Board.addBorder
 
     pub def testBoard04(): Board =
-        randomBoard(719_657i64, rows=15, 10, 0.3f32)
+        randomBoard(719_657i64, rows=15, 10, 0.3)
+    
+    pub def testBoard05(): Board =
+        automataBoard(285_041_125i64, rows=25, 40, 0.38, 3)
 
     // Test Scenarios
 
@@ -87,4 +90,7 @@ namespace TestDisplay {
 
     pub def testDisplayBoard04(): Unit & Impure =
         Flixball/Display.displayBoard(testBoard04())
+
+    pub def testDisplayBoard05(): Unit & Impure =
+        Flixball/Display.displayBoard(testBoard05())
 }

--- a/test/TestNoise.flix
+++ b/test/TestNoise.flix
@@ -1,0 +1,14 @@
+namespace TestNoise {
+
+    @test
+    def testBoolNoise2d01(): Bool = region r {
+        let ans = Flixball/Noise.boolNoise2d(r, {width=5, height=4}, 512i64, 0.0);
+        ans |> Array.forall(Array.forall(b -> b == false))
+    }
+
+    @test
+    def testBoolNoise2d02(): Bool = region r {
+        let ans = Flixball/Noise.boolNoise2d(r, {width=5, height=4}, 512i64, 1.0);
+        ans |> Array.forall(Array.forall(b -> b == true))
+    }
+}


### PR DESCRIPTION
Idea of cellular automata:
1) generate a random noise board
2) define rules for each cell (a la conways game of life) that express that lonely walls should go away and lonely empty spots should be walls
3) apply these rules over a couple iterations

result: The board is now more cohesive

Related to #3