### PR TITLE
refactor: make `GameState` opaque

### DIFF
--- a/src/Core/AiInfo.flix
+++ b/src/Core/AiInfo.flix
@@ -1,7 +1,6 @@
 namespace Flixball/Core/AiInfo {
     use Flixball/Core.Coordinates
     use Flixball/Core/GameState.GameState
-    use Flixball/Core/GameState.GameState.GameState
     use Flixball/Core.PlayerId
     use Flixball/Core.Position
     use Flixball/Core.Tile
@@ -9,6 +8,10 @@ namespace Flixball/Core/AiInfo {
     use Flixball/Core/Board.Board.Board
 
     pub opaque enum AiInfo(Board, Map[PlayerId, Position])
+
+    pub def init(board: Board, players: Map[PlayerId, Position]): AiInfo = {
+        AiInfo(board, players)
+    }
 
     pub def getTiles(i: AiInfo): Map[Coordinates, Tile] = {
         let AiInfo(Board(br), _) = i;
@@ -29,10 +32,4 @@ namespace Flixball/Core/AiInfo {
         let AiInfo(_, players) = i;
         players
     }
-    
-    pub def fromState(gs: GameState): AiInfo = {
-        let GameState(_, _, players, board) = gs;
-        AiInfo(board, players)
-    }
-
 }

--- a/src/Core/Engine.flix
+++ b/src/Core/Engine.flix
@@ -7,9 +7,9 @@ namespace Flixball/Core/GameState/Engine {
     use Flixball/Core/Board.{get_, players};
     use Flixball/Core/GameState.GameState;
     use Flixball/Core/GameState.GameState.GameState;
-    use Flixball/Core/GameState.setStates;
     use Flixball/GridGraph.raytraceEx;
     use Flixball/Core/GameState.getPosition;
+    use Flixball/Core/GameState.rec;
 
     ///
     /// Returns an iterator over the game states in this game.
@@ -30,21 +30,20 @@ namespace Flixball/Core/GameState/Engine {
     /// Resolves one step of the GameState.
     ///
     pub def runStep(gs: GameState): GameState = region r {
-        let GameState(states0, moveLogics, playerPositions, board) = gs;
         let newStates = new MutMap(r);
-        let moves = players(board) |>
+        let moves = players(rec(gs).board) |>
             List.map(match (id, _) ->
                 use Option.flatMap;
-                let* move = Map.get(id, moveLogics);
-                let* state0 = Map.get(id, states0);
-                let aiInfo = Flixball/Core/AiInfo.init(board, playerPositions);
+                let* move = Map.get(id, rec(gs).moveLogics);
+                let* state0 = Map.get(id, rec(gs).aiStates);
+                let aiInfo = Flixball/Core/AiInfo.init(rec(gs).board, rec(gs).players);
                 let (moveToDo, state) = move(aiInfo, state0);
                 MutMap.put!(id, state, newStates);
                 Some((id, moveToDo))
             ) |>
             List.map(Utils/Option.unsafeGet) |> List.toMap;
         // Everything in gamestate except the values in player states is handled in resolve.
-        resolve(moves, gs |> setStates(MutMap.toMap(newStates)))
+        resolve(moves, GameState({ aiStates = MutMap.toMap(newStates) | rec(gs)}))
     }
     
     ///
@@ -68,7 +67,6 @@ namespace Flixball/Core/GameState/Engine {
                 case Walk => None
             });
         let state2 = (state1, rotators) ||> Map.foldLeftWithKey((acc, id) -> rot -> Flixball/Core/GameState.rotatePlayer(id, rot, acc));
-        let GameState(_, _, _, board2) = state2;
 
         let movers = moves1
             |> Map.filter(Eq.eq(Walk))
@@ -78,7 +76,7 @@ namespace Flixball/Core/GameState/Engine {
             |> List.filterMap(mover -> getPosition(mover, state2) |> Option.map(match Position(coords, dir) -> (mover, step(coords, dir))))
             |> List.toMap;
         let newPos = maybeNewPos 
-            |> Map.filter(coords -> (board2 |> get_(coords)) |> Option.isEmpty)
+            |> Map.filter(coords -> (rec(state2).board |> get_(coords)) |> Option.isEmpty)
             |> withUniqueValues;
         // a new position cannot be a wall, a previous player's position, or a new player's position
         let state3 = (state2, newPos) ||> Map.foldLeftWithKey((acc, id) -> coords -> Flixball/Core/GameState.movePlayer(id, coords, acc));
@@ -105,10 +103,9 @@ namespace Flixball/Core/GameState/Engine {
     /// Returns the player killed by the shot.
     ///
     def resolveShot(state: GameState, shooter: PlayerId): Option[PlayerId] = {
-        let GameState(_, _, _, board) = state;
         use Option.flatMap;
         let* Position(coords0, dir) = getPosition(shooter, state);
-        match raytraceEx(dir, coords0, board) {
+        match raytraceEx(dir, coords0, rec(state).board) {
             case Some(Person(id, _)) => Some(id)
             case Some(Wall) => None
             case None => None

--- a/src/Core/Engine.flix
+++ b/src/Core/Engine.flix
@@ -1,13 +1,15 @@
-namespace Flixball/Engine {
+namespace Flixball/Core/GameState/Engine {
     use Flixball/Core.{Move, step, PlayerId, Position};
-    use Flixball/Core/GameState.GameState.GameState;
-    use Flixball/Core/GameState.GameState;
     use Flixball/Core.Move.{Shoot, Turn, Walk};
     use Flixball/Core.MoveLogic;
     use Flixball/Core.Position.Position;
     use Flixball/Core.Tile.{Person, Wall};
     use Flixball/Core/Board.{get_, players};
+    use Flixball/Core/GameState.GameState;
+    use Flixball/Core/GameState.GameState.GameState;
+    use Flixball/Core/GameState.setStates;
     use Flixball/GridGraph.raytraceEx;
+    use Flixball/Core/GameState.getPosition;
 
     ///
     /// Returns an iterator over the game states in this game.
@@ -35,13 +37,14 @@ namespace Flixball/Engine {
                 use Option.flatMap;
                 let* move = Map.get(id, moveLogics);
                 let* state0 = Map.get(id, states0);
-                let (moveToDo, state) = move(gs |> Flixball/Core/AiInfo.fromState, state0);
+                let aiInfo = Flixball/Core/AiInfo.init(board, playerPositions);
+                let (moveToDo, state) = move(aiInfo, state0);
                 MutMap.put!(id, state, newStates);
                 Some((id, moveToDo))
             ) |>
             List.map(Utils/Option.unsafeGet) |> List.toMap;
         // Everything in gamestate except the values in player states is handled in resolve.
-        resolve(moves, GameState(MutMap.toMap(newStates), moveLogics, playerPositions, board))
+        resolve(moves, gs |> setStates(MutMap.toMap(newStates)))
     }
     
     ///
@@ -110,14 +113,6 @@ namespace Flixball/Engine {
             case Some(Wall) => None
             case None => None
         }
-    }
-
-    ///
-    /// Gets the position of the given player.
-    ///
-    def getPosition(id: PlayerId, state: GameState): Option[Position] = {
-        let GameState(_, _, playerPositions, _) = state;
-        playerPositions |> Map.get(id)
     }
 
 }

--- a/src/Core/GameState.flix
+++ b/src/Core/GameState.flix
@@ -14,12 +14,26 @@ namespace Flixball/Core/GameState {
     use Flixball/Core/Board.get_
     use Flixball/Core/Board.set_
 
-    pub enum GameState(
+    pub opaque enum GameState(
         Map[PlayerId, AiState],
         Map[PlayerId, MoveLogic],
         Map[PlayerId, Position],
         Board
     )
+
+    pub def init(seed: Int64, strategies: Map[PlayerId, Strategy], b: Board): GameState = {
+        let playerMap = Flixball/Core/Board.players(b) |> List.toMap;
+        let (states, moveLogics) = strategies |> Map.mapWithKey((id, strat) -> {
+            let (stateGen, ml) = strat(id);
+            (stateGen(seed), ml)
+        }) |> Utils/Map.unzip;
+        GameState(states, moveLogics, playerMap, b)
+    }
+
+    pub def board(gs: GameState): Board = {
+        let GameState(_, _, _, board) = gs;
+        board
+    }
 
     /// Removes a player from the game.
     /// Does nothing if the player does not exist in the game.
@@ -82,13 +96,17 @@ namespace Flixball/Core/GameState {
             }
         }
     }
-    
-    pub def mkGameState(seed: Int64, strategies: Map[PlayerId, Strategy], b: Board): GameState = {
-        let playerMap = Flixball/Core/Board.players(b) |> List.toMap;
-        let (states, moveLogics) = strategies |> Map.mapWithKey((id, strat) -> {
-            let (stateGen, ml) = strat(id);
-            (stateGen(seed), ml)
-        }) |> Utils/Map.unzip;
-        GameState(states, moveLogics, playerMap, b)
+
+    def setStates(aiStates: Map[PlayerId, AiState], gs: GameState): GameState = {
+        let GameState(_, moveLogics, playerMap, board) = gs;
+        GameState(aiStates, moveLogics, playerMap, board)
+    }
+
+    ///
+    /// Gets the position of the given player.
+    ///
+    def getPosition(id: PlayerId, state: GameState): Option[Position] = {
+        let GameState(_, _, playerPositions, _) = state;
+        playerPositions |> Map.get(id)
     }
 }

--- a/src/Core/GameState.flix
+++ b/src/Core/GameState.flix
@@ -14,12 +14,21 @@ namespace Flixball/Core/GameState {
     use Flixball/Core/Board.get_
     use Flixball/Core/Board.set_
 
-    pub opaque enum GameState(
-        Map[PlayerId, AiState],
-        Map[PlayerId, MoveLogic],
-        Map[PlayerId, Position],
-        Board
-    )
+    pub opaque enum GameState(GameStateRecord)
+
+    type alias GameStateRecord = {
+        aiStates   = Map[PlayerId, AiState],
+        moveLogics = Map[PlayerId, MoveLogic],
+        players    = Map[PlayerId, Position],
+        board      = Board
+    }
+
+    def rec(gs: GameState): GameStateRecord = {
+        let GameState(r) = gs;
+        r
+    }
+
+    pub def board(gs: GameState): Board = rec(gs).board
 
     pub def init(seed: Int64, strategies: Map[PlayerId, Strategy], b: Board): GameState = {
         let playerMap = Flixball/Core/Board.players(b) |> List.toMap;
@@ -27,28 +36,27 @@ namespace Flixball/Core/GameState {
             let (stateGen, ml) = strat(id);
             (stateGen(seed), ml)
         }) |> Utils/Map.unzip;
-        GameState(states, moveLogics, playerMap, b)
-    }
-
-    pub def board(gs: GameState): Board = {
-        let GameState(_, _, _, board) = gs;
-        board
+        GameState({aiStates = states, moveLogics = moveLogics, players = playerMap, board = b})
     }
 
     /// Removes a player from the game.
     /// Does nothing if the player does not exist in the game.
     pub def removePlayer(id: PlayerId, state0: GameState): GameState = {
-        let GameState(states0, moveLogics, playerPositions0, board0) = state0;
-        match (playerPositions0 |> Map.get(id)) {
+        match (rec(state0).players |> Map.get(id)) {
             // Case 1: No such player. Do nothing.
             case None => state0
 
             // Case 2: Found the player. Remove from the map, the board, and the states.
             case Some(Position(coords, _)) => {
-                let playerPositions = playerPositions0 |> Map.remove(id);
-                let states = states0 |> Map.remove(id);
-                let board = board0 |> set_(coords, None);
-                GameState(states, moveLogics, playerPositions, board)
+                let playerPositions = rec(state0).players |> Map.remove(id);
+                let states = rec(state0).aiStates |> Map.remove(id);
+                let board = rec(state0).board |> set_(coords, None);
+                GameState({
+                    aiStates = states,
+                    players  = playerPositions,
+                    board    = board |
+                    rec(state0)
+                })
             }
         }
     }
@@ -56,21 +64,24 @@ namespace Flixball/Core/GameState {
     /// Rotates a player with the given rotation.
     /// Does nothing if the player does not exist in the game.
     pub def rotatePlayer(id: PlayerId, rot: Rotation, state0: GameState): GameState = {
-        let GameState(states, moveLogics, playerPositions0, board0) = state0;
-        match (playerPositions0 |> Map.get(id)) {
+        match (rec(state0).players |> Map.get(id)) {
             // Case 1: No such player. Do nothing.
             case None => state0
 
             // Case 2: Found the player. Change their direction in the map and the board.
             case Some(Position(coords, dir0)) => {
                 let dir = dir0 |> rotateDir(rot);
-                let playerPositions = playerPositions0 |> Map.insert(id, Position(coords, dir));
-                let board = (coords, board0) ||> adjust(tileOpt -> match tileOpt {
+                let playerPositions = rec(state0).players |> Map.insert(id, Position(coords, dir));
+                let board = (coords, rec(state0).board) ||> adjust(tileOpt -> match tileOpt {
                         case Some(Person(_, _)) => Some(Person(id, dir))
                         case other => other
                     }
                 );
-                GameState(states, moveLogics, playerPositions, board)
+                GameState({
+                    players  = playerPositions,
+                    board    = board |
+                    rec(state0)
+                })
             }
         }
     }
@@ -78,35 +89,31 @@ namespace Flixball/Core/GameState {
     /// Moves a player to a new position.
     /// Does not change the direction of the player.
     pub def movePlayer(id: PlayerId, coords: Coordinates, state0: GameState): GameState = {
-        let GameState(states, moveLogics, playerPositions0, board0) = state0;
-        match (playerPositions0 |> Map.get(id)) {
+        match (rec(state0).players |> Map.get(id)) {
             // Case 1: No such player. Do nothing.
             case None => state0
 
             // Case 2: Found the player. Change their position in the map and the board.
             case Some(Position(coords0, dir)) => {
-                let playerPositions = playerPositions0 |> Map.insert(id, Position(coords, dir));
-                match get_(coords0, board0) {
+                let playerPositions = rec(state0).players |> Map.insert(id, Position(coords, dir));
+                match get_(coords0, rec(state0).board) {
                     case None => bug!("invalid game state")
                     case Some(person) => {
-                        let board = board0 |> set_(coords0, None) |> set_(coords, Some(person));
-                        GameState(states, moveLogics, playerPositions, board)
+                        let board = rec(state0).board |> set_(coords0, None) |> set_(coords, Some(person));
+                        GameState({
+                            players  = playerPositions,
+                            board    = board |
+                            rec(state0)
+                        })
                     }
                 }
             }
         }
     }
 
-    def setStates(aiStates: Map[PlayerId, AiState], gs: GameState): GameState = {
-        let GameState(_, moveLogics, playerMap, board) = gs;
-        GameState(aiStates, moveLogics, playerMap, board)
-    }
-
     ///
     /// Gets the position of the given player.
     ///
-    def getPosition(id: PlayerId, state: GameState): Option[Position] = {
-        let GameState(_, _, playerPositions, _) = state;
-        playerPositions |> Map.get(id)
-    }
+    def getPosition(id: PlayerId, state: GameState): Option[Position] =
+        rec(state).players |> Map.get(id)
 }

--- a/src/Display.flix
+++ b/src/Display.flix
@@ -5,7 +5,7 @@ namespace Flixball/Display {
     use Flixball/Core/Board.Board;
     use Flixball/Core/Board.Board.Board;
     use Flixball/Core/GameState.GameState;
-    use Flixball/Core/GameState.GameState.GameState;
+    use Flixball/Core/GameState.{board => gameStateBoard};
 
     ///
     /// Clears then screen and then displays the board. The cursor will be left
@@ -22,10 +22,9 @@ namespace Flixball/Display {
     ///
     pub def runGameState(delayDuration: Int64, gs: GameState): Unit & Impure = {
         import static java.lang.Thread.sleep(Int64): Unit & Impure;
-        let GameState(_, _, _, board) = gs;
-        displayBoard(board);
+        gameStateBoard(gs) |> displayBoard;
         sleep(delayDuration);
-        runGameState(delayDuration, Flixball/Engine.runStep(gs))
+        runGameState(delayDuration, Flixball/Core/GameState/Engine.runStep(gs))
     }
 
     def boardLines(b: Board): List[String] = region r {

--- a/test/TestDisplay.flix
+++ b/test/TestDisplay.flix
@@ -6,7 +6,7 @@ namespace TestDisplay {
     use Flixball/Core.Rotation.{Clockwise, Counterclockwise};
     use Flixball/Core.Tile.{Person, Wall};
     use Flixball/Core/Board.{automataBoard, randomBoard};
-    use Flixball/Core/GameState.mkGameState;
+    use Flixball/Core/GameState.init;
     use Flixball/AiLibrary.{
         rotate, shoot, walk, spinAndShoot, goAndSpin, naiveSearchAndDestroy,
         wander, smartSearchAndDestroy
@@ -149,21 +149,21 @@ namespace TestDisplay {
         // OBS letbinding is avoided because of bug
         // https://github.com/flix/flix/issues/4440
         testBoard01() |> match (board, strategies) ->
-        runGameState(500i64, mkGameState(42i64, strategies, board))
+        runGameState(500i64, init(42i64, strategies, board))
 
     pub def testDisplayBoard02(): Unit & Impure =
         displayBoard(fst(testBoard02()))
 
     pub def testRunBoard02(): Unit & Impure =
         testBoard02() |> match (board, strategies) ->
-        runGameState(500i64, mkGameState(42i64, strategies, board))
+        runGameState(500i64, init(42i64, strategies, board))
 
     pub def testDisplayBoard03(): Unit & Impure =
         displayBoard(fst(testBoard03()))
 
     pub def testRunBoard03(): Unit & Impure =
         testBoard03() |> match (board, strategies) ->
-        runGameState(500i64, mkGameState(42i64, strategies, board))
+        runGameState(500i64, init(42i64, strategies, board))
 
     pub def testDisplayBoard04(): Unit & Impure =
         displayBoard(testBoard04())
@@ -173,10 +173,10 @@ namespace TestDisplay {
 
     pub def testRunBoard06(): Unit & Impure =
         testBoard06() |> match (board, strategies) ->
-        runGameState(500i64, mkGameState(42i64, strategies, board))
+        runGameState(500i64, init(42i64, strategies, board))
 
     pub def testRunBoard07(): Unit & Impure =
         testBoard07() |> match (board, strategies) ->
-        runGameState(500i64, mkGameState(42i64, strategies, board))
+        runGameState(500i64, init(42i64, strategies, board))
 
 }


### PR DESCRIPTION
Fixes part of #17.

I don't know if this makes sense or not. I'm not used to thinking like this in flix. opaque forces you to separate functions into internal vs external. I suppose Engine is internal to GameState right?