### PR TITLE
chore: `for` -> `forM` and `class` -> `trait`

### DIFF
--- a/src/AiLibrary.flix
+++ b/src/AiLibrary.flix
@@ -196,7 +196,7 @@ mod Flixball.AiLibrary {
             else
                 Map.get(c, tiles) == None
         };
-        for (
+        forM (
             moves <- findShortestPath(availablePosition, p, goal);
             res <- List.head(moves)
         ) yield {

--- a/src/BoardLibrary.flix
+++ b/src/BoardLibrary.flix
@@ -63,7 +63,7 @@ mod Flixball.BoardLibrary {
         let rows = List.range(0, rec.rows);
         let cols = List.range(0, rec.cols);
         let options = {
-            for (
+            forM (
                 row <- rows;
                 col <- cols;
                 if (Map.get((row, col), rec.tiles) == None)

--- a/src/Config.flix
+++ b/src/Config.flix
@@ -16,7 +16,7 @@ mod Flixball.Config {
     /// Reads the run configuration from a JSON string.
     ///
     pub def read(json: String): Result[String, Config] = {
-        for (
+        forM (
             obj <- Json.Parse.parse(json) |> Option.toOk("invalid JSON");
             res <- fromJson(obj)
         ) yield {
@@ -25,7 +25,7 @@ mod Flixball.Config {
     }
 
     def fromJson(json: JsonElement): Result[String, Config] = {
-        for (
+        forM (
             o <- asObject(".", json);
             mapJson <- Map.get("map", o) |> Option.toOk("missing key 'map'");
             playersJson <- Map.get("players", o) |> Option.toOk("missing key 'players'");
@@ -41,7 +41,7 @@ mod Flixball.Config {
 
     def readMap(json: JsonElement): Result[String, (Int32, Int64) -> Board] = match json {
         case JsonObject(o) => {
-            for (
+            forM (
                 id0 <- Map.get("id", o) |> Option.toOk("missing key 'map.id'");
                 id <- asString(".map", id0);
                 data <- Map.get("data", o) |> Ok;
@@ -52,7 +52,7 @@ mod Flixball.Config {
     }
 
     def readPlayers(json: JsonElement): Result[String, List[Strategy]] = {
-        for (
+        forM (
             a <- asArray(".players", json);
             res <- Result.traverse(readPlayer, a)
         ) yield {
@@ -61,7 +61,7 @@ mod Flixball.Config {
     }
 
     def readPlayer(json: JsonElement): Result[String, Strategy] = {
-        for (
+        forM (
             o <- asObject(".players[_]", json);
             id0 <- Map.get("id", o) |> Option.toOk("missing key 'players[_].id'");
             id <- asString(".players[_]", id0);
@@ -78,7 +78,7 @@ mod Flixball.Config {
     def mkMap(id: String, data: Option[JsonElement]): Result[String, (Int32, Int64) -> Board] = match id {
         case "random" => match data {
             case Some(json) => {
-                for (
+                forM (
                 o <- asObject("map.data", json);
                 rows0 <- Map.get("rows", o) |> Option.toOk("missing key 'map.data.rows'");
                 cols0 <- Map.get("cols", o) |> Option.toOk("missing key 'map.data.cols'");

--- a/src/Engine.flix
+++ b/src/Engine.flix
@@ -107,7 +107,7 @@ mod Flixball.Engine {
     /// Returns the player killed by the shot.
     ///
     def resolveShot(state: GameState, shooter: PlayerId): Option[PlayerId] = {
-        for (
+        forM (
             Position(coords0, dir) <- playerPosition(shooter, state);
             res <- match raytraceEx(dir, coords0, gsBoard(state)) {
                 case Some(Person(id, _)) => Some(id)

--- a/src/Main.flix
+++ b/src/Main.flix
@@ -52,7 +52,7 @@ mod Flixball.Main {
                 case _ => None
             })
             |> Option.getWithDefault(Random.nextInt64(Random.fresh()));
-        for (
+        forM (
             configPath <- runOpts
                 |> List.findMap(x -> match x {
                     case RunOption.Config(c) => Some(c)

--- a/src/Options.flix
+++ b/src/Options.flix
@@ -98,7 +98,7 @@ mod Flixball.Options {
     def dimensions(d: String): Option[Flag] = {
         match String.splitOn(substr = "x", d) {
             case rows0 :: cols0 :: Nil => {
-                for (
+                forM (
                     rows <- Int32.fromString(rows0);
                     cols <- Int32.fromString(cols0)
                 ) yield {

--- a/src/State.flix
+++ b/src/State.flix
@@ -2,7 +2,7 @@ mod Flixball {
     use Flixball.Core.AiState;
     use Flixball.Core.AiState.{Value, Collection};
 
-    pub lawful class State[a] {
+    pub lawful trait State[a] {
         pub def toState(x: a): AiState
         pub def fromState(x: AiState): Option[a]
 
@@ -10,7 +10,7 @@ mod Flixball {
             Flixball.State.fromState(Flixball.State.toState(x)) == Some(x)
     }
 
-    pub class MutState[m: Region -> Type] {
+    pub trait MutState[m: Region -> Type] {
         pub def toState(x: m[r]): AiState \ r
         pub def fromState(r: Region[r], x: AiState): Option[m[r]] \ r
     }
@@ -81,7 +81,7 @@ mod Flixball {
         }
 
         pub def fromState(x: AiState): Option[Map[k, v]] = {
-            for (
+            forM (
                 list <- Flixball.State.fromState(x)
             ) yield {
                 List.toMap(list)


### PR DESCRIPTION
With the new parser `for` becomes deprecated in favor of `forM`. Likewise `class` gets dropped in favor of `trait`