### PR TITLE
chore: bump `flix-json` version

### DIFF
--- a/flix.toml
+++ b/flix.toml
@@ -7,4 +7,4 @@ authors = ["Matthew Lutze", "Jonathan Starup"]
 
 [dependencies]
 "github:JonathanStarup/Flix-ANSI-Terminal" = "1.8.0"
-"github:mlutze/flix-json" = "0.12.17"
+"github:mlutze/flix-json" = "0.12.18"


### PR DESCRIPTION
For when https://github.com/mlutze/flix-json/pull/95 is merged and released